### PR TITLE
"Pneumatics and PWM TIMER 3, 4, 8"

### DIFF
--- a/dev/Makefile
+++ b/dev/Makefile
@@ -124,7 +124,7 @@ CSRC = $(STARTUPSRC) \
 			 $(CHIBIOS)/os/hal/lib/streams/memstreams.c \
        $(CHIBIOS)/os/hal/lib/streams/chprintf.c \
        main.c shellcfg.c flash.c tft_display.c \
-			 mpu6500.c attitude.c math_misc.c \
+			 mpu6500.c attitude.c ist8310.c math_misc.c \
 			 canBusProcess.c dbus.c gimbal.c params.c usbcfg.c \
 			 calibrate_sensor.c
 

--- a/dev/Makefile
+++ b/dev/Makefile
@@ -104,6 +104,7 @@ include $(CHIBIOS)/os/rt/rt.mk
 include $(CHIBIOS)/os/rt/ports/ARMCMx/compilers/GCC/mk/port_v7m.mk
 # Other files (optional).
 #include $(CHIBIOS)/test/rt/test.mk
+include $(CHIBIOS)/dsp/dsp.mk
 
 # Define linker script file here
 LDSCRIPT= $(STARTUPLD)/STM32F429xI.ld
@@ -118,15 +119,17 @@ CSRC = $(STARTUPSRC) \
        $(PLATFORMSRC) \
        $(BOARDSRC) \
        $(TESTSRC) \
+       $(MATHSRC) \
 			 $(CHIBIOS)/os/various/shell.c \
        $(CHIBIOS)/os/various/evtimer.c \
        $(CHIBIOS)/os/various/syscalls.c \
 			 $(CHIBIOS)/os/hal/lib/streams/memstreams.c \
        $(CHIBIOS)/os/hal/lib/streams/chprintf.c \
        main.c shellcfg.c flash.c tft_display.c \
-			 mpu6500.c attitude.c ist8310.c math_misc.c \
-			 canBusProcess.c dbus.c gimbal.c params.c usbcfg.c \
-			 calibrate_sensor.c
+			 mpu6500.c attitude.c math_misc.c \
+			 canBusProcess.c dbus.c params.c usbcfg.c \
+			 calibrate_sensor.c gimbal_sys_iden.c shoot_pwm.c\
+			 pwm_struct.c
 
 # C++ sources that can be compiled in ARM or THUMB mode depending on the global
 # setting.
@@ -158,6 +161,7 @@ ASMSRC = $(STARTUPASM) $(PORTASM) $(OSALASM)
 #define SERIAL_DATA      &SDU1
 INCDIR = $(STARTUPINC) $(KERNINC) $(PORTINC) $(OSALINC) \
          $(HALINC) $(PLATFORMINC) $(BOARDINC) $(TESTINC) \
+         $(CHIBIOS)/dev \
          $(CHIBIOS)/os/various \
 				 $(CHIBIOS)/os/hal/lib/streams \
 				 inc -lm

--- a/dev/attitude.c
+++ b/dev/attitude.c
@@ -1,3 +1,10 @@
+/**
+ * Edward ZHANG, 20170910
+ * @file        attitude.c
+ * @brief       Attitude estimator using quaternion and complementary filter
+ * @reference   PX4  src/lib/ecl/attitude_estimator_q.cpp
+ */
+
 #include "ch.h"
 #include "hal.h"
 

--- a/dev/calibrate_sensor.c
+++ b/dev/calibrate_sensor.c
@@ -1,3 +1,10 @@
+/**
+ * Edward ZHANG, 201710??
+ * @file        calibrate_sensor.c
+ * @brief       Sensor calibration functions
+ * @reference   PX4
+ */
+
 #include "ch.h"
 #include "hal.h"
 #include "math_misc.h"

--- a/dev/canBusProcess.c
+++ b/dev/canBusProcess.c
@@ -2,6 +2,7 @@
  * Edward ZHANG, 20171101
  * @file    canBusProcess.c
  * @brief   CAN driver configuration file
+ * @reference   RM2017_Archive
  */
 #include "ch.h"
 #include "hal.h"

--- a/dev/dbus.c
+++ b/dev/dbus.c
@@ -1,3 +1,9 @@
+/**
+ * Edward ZHANG, Terry ZENG, 201709??
+ * @file    dbus.c
+ * @brief   Dbus driver and decoder
+ */
+
 #include "ch.h"
 #include "hal.h"
 

--- a/dev/gimbal.c
+++ b/dev/gimbal.c
@@ -261,6 +261,7 @@ static THD_FUNCTION(gimbal_thread, p)
 
     //TODO Yaw mixer is not aligned
     gimbal.yaw_speed_cmd = -sinroll * pitch_atti_out + cospitch * cosroll * yaw_atti_out;
+    gimbal.yaw_speed_cmd /= cosf(yaw_theta1);
     gimbal.pitch_speed_cmd = cosroll * pitch_atti_out + cospitch * sinroll * yaw_atti_out;
 
     gimbal.yaw_iq_cmd = gimbal_controlSpeed(&_yaw_vel,
@@ -275,7 +276,8 @@ static THD_FUNCTION(gimbal_thread, p)
     float ff_pitch = norm_vector3_projection(gimbal._pIMU->accelData, gimbal.axis_ff_accel);
     gimbal.pitch_iq_cmd += gimbal.axis_ff_weight[GIMBAL_PITCH] * ff_pitch;
 
-    /*the reference acceleration vector is calculated in this way
+    /*
+     * the reference acceleration vector is calculated in this way
      * RefX = G * cos(tan-1(M2*cos(theta)/M1)) * cos(theta + pitch0)
      * RefY = G * sin(tan-1(M2*cos(theta)/M1))
      * RefZ = G * cos(tan-1(M2*cos(theta)/M1)) * sin(theta + pitch0)

--- a/dev/halconf.h
+++ b/dev/halconf.h
@@ -39,6 +39,33 @@
 #define LEDR_OFF()      (palSetPad(GPIOE, GPIOE_LED_R))
 #define LEDR_TOGGLE()   (palTogglePad(GPIOE, GPIOE_LED_R))
 
+#define LEDB_ON()       (palClearPad(GPIOA, GPIOA_TIM2_CH3))
+#define LEDB_OFF()      (palSetPad(GPIOA, GPIOA_TIM2_CH3))
+#define LEDB_TOGGLE()   (palTogglePad(GPIOA, GPIOA_TIM2_CH3))
+#define LEDO_ON()       (palClearPad(GPIOA, GPIOA_TIM2_CH2))
+#define LEDO_OFF()      (palSetPad(GPIOA, GPIOA_TIM2_CH2))
+#define LEDO_TOGGLE()   (palTogglePad(GPIOA, GPIOA_TIM2_CH2))
+
+//Sets of command for Pneumatics Output
+#define PN1_ON()        (palSetPad(GPIOD, GPIOD_PNEUMATICS1))
+#define PN2_ON()        (palSetPad(GPIOD, GPIOD_PNEUMATICS2))
+#define PN3_ON()        (palSetPad(GPIOH, GPIOH_PNEUMATICS3))
+#define PN4_ON()        (palSetPad(GPIOH, GPIOH_PNEUMATICS4))
+#define PN5_ON()        (palSetPad(GPIOH, GPIOH_PNEUMATICS5))
+#define PN6_ON()        (palSetPad(GPIOI, GPIOI_PNEUMATICS6))
+#define PN1_OFF()       (palClearPad(GPIOD, GPIOD_PNEUMATICS1))
+#define PN2_OFF()       (palClearPad(GPIOD, GPIOD_PNEUMATICS2))
+#define PN3_OFF()       (palClearPad(GPIOH, GPIOH_PNEUMATICS3))
+#define PN4_OFF()       (palClearPad(GPIOH, GPIOH_PNEUMATICS4))
+#define PN5_OFF()       (palClearPad(GPIOH, GPIOH_PNEUMATICS5))
+#define PN6_OFF()       (palClearPad(GPIOI, GPIOI_PNEUMATICS6))
+#define PN1_TOGGLE()    (palTogglePad(GPIOD, GPIOD_PNEUMATICS1))
+#define PN2_TOGGLE()    (palTogglePad(GPIOD, GPIOD_PNEUMATICS2))
+#define PN3_TOGGLE()    (palTogglePad(GPIOH, GPIOH_PNEUMATICS3))
+#define PN4_TOGGLE()    (palTogglePad(GPIOH, GPIOH_PNEUMATICS4))
+#define PN5_TOGGLE()    (palTogglePad(GPIOH, GPIOH_PNEUMATICS5))
+#define PN6_TOGGLE()    (palTogglePad(GPIOI, GPIOI_PNEUMATICS6))
+
 /**
  * @brief   Enables the PAL subsystem.
  */
@@ -120,7 +147,7 @@
  * @brief   Enables the PWM subsystem.
  */
 #if !defined(HAL_USE_PWM) || defined(__DOXYGEN__)
-#define HAL_USE_PWM                 FALSE
+#define HAL_USE_PWM                 TRUE
 #endif
 
 /**

--- a/dev/inc/ist8310.h
+++ b/dev/inc/ist8310.h
@@ -1,0 +1,69 @@
+#ifndef _IST8310_H_
+#define _IST8310_H_
+
+/* To specify that this sensor is the slave of an IMU, i.e. MPU6500*/
+#ifndef IMU_SLAVE
+#define IMU_SLAVE
+#endif
+
+#define IST8310_PSC 0.003f
+#define IST8310_SINGLE_MEASUREMENT    0
+#define IST8310_SAMPLE_RATE_1_2HZ   255
+
+#define IST8310_RESET()     (palClearPad(GPIOE,GPIOE_IST8310_RST))
+#define IST8310_SET()       (palSetPad(GPIOE,GPIOE_IST8310_RST))
+
+/*
+ * NOTE: Read the schematic to find out the I2C address of IST8310
+ * IST8310_ADDR_$(CAD1_HIGH)_$(CAD0_HIGH) or IST8310_ADDR_FLOATING
+ */
+typedef enum{
+  IST8310_ADDR_FLOATING = 0x0E,
+  IST8310_ADDR_0_0      = 0x0C,
+  IST8310_ADDR_0_1      = 0x0D,
+  IST8310_ADDR_1_0      = 0x0E,
+  IST8310_ADDR_1_1      = 0x0F
+
+} ist8310_i2c_addr_t;
+
+typedef enum {
+  IST8310_AXIS_REV_NO = 0,
+  IST8310_AXIS_REV_X = 1,
+  IST8310_AXIS_REV_Y = 2,
+  IST8310_AXIS_REV_Z = 4,
+} ist8310_axis_rev_t;
+
+typedef enum{
+  IST8310_INVALID_SAMPLE_RATE = 1
+} ist8310_error_flag_t;
+
+typedef struct{
+  ist8310_i2c_addr_t addr;
+  uint8_t sample_rate;
+  uint8_t axis_rev;
+}magConfigStruct;
+
+typedef struct{
+  bool _inited;
+  uint32_t errorFlag;
+
+  volatile float data[3];
+  float _offset[3];
+  bool  _axis_rev[3];
+
+  #ifdef IMU_SLAVE
+    SPIDriver* _spi;
+  #else
+    ist8310_i2c_addr_t addr;
+  #endif
+}magStruct;
+
+magStruct* ist8310_get(void);
+
+volatile float* ist8310_getValue(void);
+uint32_t ist8310_getError(void);
+
+uint8_t ist8310_init(const magConfigStruct* const conf);
+uint8_t ist8310_update(void);
+
+#endif

--- a/dev/inc/main.h
+++ b/dev/inc/main.h
@@ -15,6 +15,7 @@
 #include "params.h"
 
 #include "mpu6500.h"
+#include "ist8310.h"
 #include "attitude.h"
 #include "calibrate_sensor.h"
 

--- a/dev/inc/mpu6500.h
+++ b/dev/inc/mpu6500.h
@@ -50,6 +50,55 @@ typedef enum {
   IMU_LOSE_FRAME = 1<<31
 } imu_att_error_t;
 
+typedef enum {
+  MPU6500_I2CMST_CLK_348K = 0,
+  MPU6500_I2CMST_CLK_333K = 1,
+  MPU6500_I2CMST_CLK_320K = 2,
+  MPU6500_I2CMST_CLK_308K = 3,
+  MPU6500_I2CMST_CLK_296K = 4,
+  MPU6500_I2CMST_CLK_286K = 5,
+  MPU6500_I2CMST_CLK_276K = 6,
+  MPU6500_I2CMST_CLK_267K = 7,
+  MPU6500_I2CMST_CLK_258K = 8,
+  MPU6500_I2CMST_CLK_500K = 9,
+  MPU6500_I2CMST_CLK_471K = 10,
+  MPU6500_I2CMST_CLK_444K = 11,
+  MPU6500_I2CMST_CLK_421K = 12,
+  MPU6500_I2CMST_CLK_400K = 13,
+  MPU6500_I2CMST_CLK_381K = 14,
+  MPU6500_I2CMST_CLK_364K = 15
+} mpu_i2cmst_clk_t;
+
+#define MPU6500_I2C_MSTR_EN          0x80
+#define MPU6500_I2C_MSTR_BYTE_SWAP   0x40
+#define MPU6500_I2C_MSTR_REG_DIS     0x20
+#define MPU6500_I2C_MSTR_GRP         0x10
+
+#define MPU6500_SPI_READ             0x80
+#define MPU6500_I2C_MSTR_READ        0x80
+
+#define MPU6500_EXT_SENS_DATA        0x49
+#define MPU6500_USER_CFG             0x6A
+#define MPU6500_I2C_MST_CTRL         0x24
+#define MPU6500_I2C_SLV0_ADDR        0x25
+#define MPU6500_I2C_SLV0_REG         0x26
+#define MPU6500_I2C_SLV0_CTRL        0x27
+#define MPU6500_I2C_SLV0_DO          0x63
+#define MPU6500_I2C_SLV1_ADDR        0x28
+#define MPU6500_I2C_SLV1_REG         0x29
+#define MPU6500_I2C_SLV1_CTRL        0x2A
+#define MPU6500_I2C_SLV1_DO          0x64
+#define MPU6500_I2C_SLV2_ADDR        0x2B
+#define MPU6500_I2C_SLV2_REG         0x2C
+#define MPU6500_I2C_SLV2_CTRL        0x2D
+#define MPU6500_I2C_SLV2_DO          0x65
+#define MPU6500_I2C_SLV3_ADDR        0x2E
+#define MPU6500_I2C_SLV3_REG         0x2F
+#define MPU6500_I2C_SLV3_CTRL        0x30
+#define MPU6500_I2C_SLV3_DO          0x66
+
+#define MPU6500_USER_I2C_MST         0x20
+
 #define IMU_ERROR_COUNT    1U
 #define IMU_WARNING_COUNT  1U
 static const char imu_error_messages[][IMU_ERROR_COUNT] =
@@ -85,7 +134,7 @@ typedef struct tagIMUStruct {
   param_t _accelT[3][3];    /* Accelerometer rotational bias matrix       */
   param_t _gyroBias[3];     /* Gyroscope bias.                 */
 
-  uint8_t _axis_rev[3];
+  bool  _axis_rev[3];
   float _accel_psc;
   float _gyro_psc;
 

--- a/dev/ist8310.c
+++ b/dev/ist8310.c
@@ -1,0 +1,195 @@
+/**
+ * Edward ZHANG, 20171217
+ * @file    ist8310.c
+ * @brief   ist8310 magnetometer driver
+ */
+
+#include "ch.h"
+#include "hal.h"
+
+#include "ist8310.h"
+
+#ifdef IMU_SLAVE
+  #include "mpu6500.h"
+#endif
+
+#define IST8310_STAT1      0x02
+#define IST8310_XOUT_L     0x03
+#define IST8310_XOUT_H     0x04
+#define IST8310_YOUT_L     0x05
+#define IST8310_YOUT_H     0x06
+#define IST8310_ZOUT_L     0x07
+#define IST8310_ZOUT_H     0x08
+#define IST8310_STAT2      0x09
+#define IST8310_CTRL1      0x0A
+#define IST8310_CTRL2      0x0B
+#define IST8310_TEMP_OUT_L 0x1C
+#define IST8310_TEMP_OUT_H 0x1D
+
+#define IST8310_STAT1_DOR  0x02
+#define IST8310_STAT1_DRDY 0x01
+
+#define IST8310_CTRL2_DREN 0x08
+#define IST8310_CTRL2_DRP  0x04
+#define IST8310_CTRL2_SRST 0x01
+
+/* ist8310 magnetometer data structure*/
+static magStruct ist8310;
+
+magStruct* ist8310_get(void)
+{
+  return &ist8310;
+}
+
+volatile float* ist8310_getValue(void)
+{
+  return ist8310.data;
+}
+
+uint32_t ist8310_getError(void)
+{
+  return ist8310.errorFlag;
+}
+
+static void magStructInit(const magConfigStruct* const conf)
+{
+  ist8310._offset[X] = 0.0f;
+  ist8310._offset[Y] = 0.0f;
+  ist8310._offset[Z] = 0.0f;
+
+  if(conf->axis_rev & IST8310_AXIS_REV_X)
+    ist8310._axis_rev[X] = 1;
+  if(conf->axis_rev & IST8310_AXIS_REV_Y)
+    ist8310._axis_rev[Y] = 1;
+  if(conf->axis_rev & IST8310_AXIS_REV_Z)
+    ist8310._axis_rev[Z] = 1;
+}
+
+/*
+ * @brief Initialize IST8310
+ * @NOTE  If the sensor is connected as the slave of IMU, we need to initialize IMU first
+ */
+uint8_t ist8310_init(const magConfigStruct* const conf)
+{
+  #ifdef IMU_SLAVE
+    PIMUStruct pIMU = imu_get();
+    ist8310._spi = pIMU->_imu_spi;
+
+    uint8_t data[5];
+    data[0] = MPU6500_I2C_MST_CTRL;
+    data[1] = MPU6500_I2CMST_CLK_400K; //set imu master i2c freq to 320kHz;
+    data[2] = conf->addr;                    //I2C_SLV0_ADDR
+    data[3] = IST8310_CTRL2;           //I2C_SLV0_REG
+    data[4] = MPU6500_I2C_MSTR_EN | 6; //I2C_SLV0_CTRL
+
+    spiAcquireBus(ist8310._spi);
+    spiSelect(ist8310._spi);
+    spiSend(ist8310._spi, 5, data);
+    spiUnselect(ist8310._spi);
+    spiReleaseBus(ist8310._spi);
+
+    data[0] = MPU6500_USER_CFG;
+    data[1] = MPU6500_USER_I2C_MST;
+    spiAcquireBus(ist8310._spi);
+    spiSelect(ist8310._spi);
+    spiSend(ist8310._spi, 2, data);
+    spiUnselect(ist8310._spi);
+    spiReleaseBus(ist8310._spi);
+
+    IST8310_RESET();
+    chThdSleepMilliseconds(100);
+    IST8310_SET();
+
+    data[0] = MPU6500_I2C_SLV0_REG;
+    data[1] = IST8310_CTRL1;
+    spiAcquireBus(ist8310._spi);
+    spiSelect(ist8310._spi);
+    spiSend(ist8310._spi, 2, data);
+    spiUnselect(ist8310._spi);
+    spiReleaseBus(ist8310._spi);
+
+    data[0] = MPU6500_I2C_SLV0_DO;
+    switch(conf->sample_rate)
+    {
+      case IST8310_SINGLE_MEASUREMENT: data[1] = 1;  break;
+      case 8:                          data[1] = 2;  break;
+      case 10:                         data[1] = 3;  break;
+      case 20:                         data[1] = 5;  break;
+      case 100:                        data[1] = 6;  break;
+      case 50:                         data[1] = 7;  break;
+      case IST8310_SAMPLE_RATE_1_2HZ:  data[1] = 9;  break;
+      case 1:                          data[1] = 10; break;
+      case 200:                        data[1] = 11; break;
+      default:
+        ist8310.errorFlag |= IST8310_INVALID_SAMPLE_RATE;
+        return 1;
+    }
+    spiAcquireBus(ist8310._spi);
+    spiSelect(ist8310._spi);
+    spiSend(ist8310._spi, 2, data);
+    spiUnselect(ist8310._spi);
+    spiReleaseBus(ist8310._spi);
+
+    chThdSleepMilliseconds(2);
+
+    data[0] = MPU6500_I2C_SLV0_ADDR;
+    data[1] = conf->addr | MPU6500_I2C_MSTR_READ;
+    data[2] = IST8310_XOUT_L;
+    spiAcquireBus(ist8310._spi);
+    spiSelect(ist8310._spi);
+    spiSend(ist8310._spi, 3, data);
+    spiUnselect(ist8310._spi);
+    spiReleaseBus(ist8310._spi);
+
+    ist8310._inited = true;
+    return 0;
+  #else
+  #endif
+}
+
+static inline uint8_t ist8310_getRawValue(uint16_t* rawData)
+{
+  #ifdef IMU_SLAVE
+    uint8_t data = MPU6500_EXT_SENS_DATA | MPU6500_I2C_MSTR_READ;
+
+    spiAcquireBus(ist8310._spi);
+    spiSelect(ist8310._spi);
+    spiSend(ist8310._spi, 1, &data);
+    spiReceive(ist8310._spi, 6, (uint8_t*)rawData);
+    spiUnselect(ist8310._spi);
+  	spiReleaseBus(ist8310._spi);
+
+    return 0;
+  #else
+  #endif
+}
+
+static void trans_magBias(void)
+{
+  uint8_t i;
+  for (i = 0; i < 3; i++)
+  {
+    ist8310.data[i] -= ist8310._offset[i];
+  }
+}
+
+/*
+ *  @brief This function updates the reading from the ist8310 magnetometer
+ */
+uint8_t ist8310_update(void)
+{
+  uint16_t rawData[3];
+  uint8_t result = ist8310_getRawValue(rawData);
+
+  uint8_t i;
+  for (i = 0; i < 3; i++)
+  {
+    if(ist8310._axis_rev[i])
+      ist8310.data[i] = (float)(-rawData[i]) * IST8310_PSC;
+    else
+      ist8310.data[i] = rawData[i] * IST8310_PSC;
+  }
+  trans_magBias();
+
+  return result;
+}

--- a/dev/main.c
+++ b/dev/main.c
@@ -19,6 +19,9 @@ static BaseSequentialStream* chp = (BaseSequentialStream*)&SDU1;
 static const IMUConfigStruct imu1_conf =
   {&SPID5, MPU6500_ACCEL_SCALE_8G, MPU6500_GYRO_SCALE_1000, MPU6500_AXIS_REV_Z};
 
+static const magConfigStruct mag1_conf =
+  {IST8310_ADDR_FLOATING, 200, IST8310_AXIS_REV_NO};
+
 PIMUStruct pIMU;
 
 #define MPU6500_UPDATE_PERIOD_US 1000000U/MPU6500_UPDATE_FREQ
@@ -30,8 +33,10 @@ static THD_FUNCTION(Attitude_thread, p)
   (void)p;
 
   imuInit(pIMU, &imu1_conf);
+  ist8310_init(&mag1_conf);
 
   uint32_t tick = chVTGetSystemTimeX();
+
   while(true)
   {
     tick += US2ST(MPU6500_UPDATE_PERIOD_US);
@@ -44,6 +49,7 @@ static THD_FUNCTION(Attitude_thread, p)
     }
 
     imuGetData(pIMU);
+    ist8310_update();
     if(pIMU->inited == 2)
       attitude_update(pIMU);
 
@@ -91,7 +97,7 @@ int main(void) {
 
   while (true)
   {
-    chThdSleepSeconds(1);
+    chThdSleepMilliseconds(500);
   }
 
   return 0;

--- a/dev/mcuconf.h
+++ b/dev/mcuconf.h
@@ -218,12 +218,12 @@
  * PWM driver system settings.
  */
 #define STM32_PWM_USE_ADVANCED              FALSE
-#define STM32_PWM_USE_TIM1                  FALSE
+#define STM32_PWM_USE_TIM1                  TRUE
 #define STM32_PWM_USE_TIM2                  FALSE
-#define STM32_PWM_USE_TIM3                  FALSE
-#define STM32_PWM_USE_TIM4                  FALSE
+#define STM32_PWM_USE_TIM3                  TRUE
+#define STM32_PWM_USE_TIM4                  TRUE
 #define STM32_PWM_USE_TIM5                  FALSE
-#define STM32_PWM_USE_TIM8                  FALSE
+#define STM32_PWM_USE_TIM8                  TRUE
 #define STM32_PWM_USE_TIM9                  FALSE
 #define STM32_PWM_TIM1_IRQ_PRIORITY         7
 #define STM32_PWM_TIM2_IRQ_PRIORITY         7

--- a/dev/mpu6500.c
+++ b/dev/mpu6500.c
@@ -1,8 +1,7 @@
 /**
- * This is device realize "read through write" paradigm. This is not
- * standard, but most of I2C devices use this paradigm.
- * You must write to device reading address, send restart to bus,
- * and then begin reading process.
+ * Edward ZHANG, 201709??
+ * @file    mpu6500.c
+ * @brief   mpu6500 six-axis imu driver
  */
 
 #include "ch.h"
@@ -57,8 +56,6 @@ typedef enum {
 #define MPU6500_SENSOR_SLEEP      0x40
 #define MPU6500_AUTO_SELECT_CLK   0x01
 
-#define MPU6500_SPI_READ          0x80
-
 typedef enum{
   DLPF_250HZ  =  0,
   DLPF_184HZ  =  1,
@@ -86,7 +83,7 @@ static const SPIConfig MPU6500_SPI_cfg =
   GPIOF,
   GPIOF_SPI5_IMU_NSS,
   SPI_CR1_BR_2 | SPI_CR1_BR_1 | SPI_CR1_MSTR |
-  SPI_CR1_CPHA | SPI_CR1_CPOL
+  SPI_CR1_CPHA | SPI_CR1_CPOL //Set CPHA and CPOL to be 1
 };
 
 /* IMU data structure. */
@@ -108,8 +105,8 @@ static uint8_t imuTXData[MPU6500_TX_BUF_SIZE];
 
 /**
  * @brief  Initialization function of IMU data structure.
- * @param  pIMU - pointer to IMU data structure;
- * @param  fAddrLow - IMU address pin A0 is pulled low flag.
+ * @param  pIMU       pointer to IMU data structure;
+ * @param  imu_conf   IMU Initialization structure
  */
 static void imuStructureInit(PIMUStruct pIMU, IMUConfigStruct* imu_conf)
 {

--- a/dev/params.c
+++ b/dev/params.c
@@ -1,3 +1,9 @@
+/**
+ * Edward ZHANG, 20171111
+ * @file    param.c
+ * @brief   parameter tuning and management interface
+ */
+
 #include "ch.h"
 #include "hal.h"
 

--- a/dev/pwm_struct.c
+++ b/dev/pwm_struct.c
@@ -12,12 +12,31 @@
 // This is the link to the CHIBIos Documentation on PWMD. You can find all the necessary functions
 // to command the PWM output in this webpage
 
+
+//These are the templates for the callback functions
+//Syntax:
+//the name of this function means PWM 3 PERIODIC CALLBACK function
+static void pwm3pcb(PWMDriver *pwmp) {
+
+  (void)pwmp;
+
+}
+
+//the name of this function means PWM 3 CHANNEL 1 CALLBACK function
+static void pwm3c1cb(PWMDriver *pwmp) {
+
+  (void)pwmp;
+
+}
+
+// These are the definitions of the PWMConfig stuctures
+// E.g. the function name means PWM 3 CONFIGURATION
 static PWMConfig pwm3cfg = {
         100000,   /* 1MHz PWM clock frequency.   */
         1000,      /* Initial PWM period 1ms.       */
-        NULL,
+        pwm3pcb,       /* Periodic call back */
         {
-                {PWM_OUTPUT_ACTIVE_HIGH, NULL},
+                {PWM_OUTPUT_ACTIVE_HIGH, pwm3c1cb}, /* {<pwm_initialisation_status>, <callback function of the channel> */
                 {PWM_OUTPUT_ACTIVE_HIGH, NULL},
                 {PWM_OUTPUT_DISABLED, NULL},
                 {PWM_OUTPUT_DISABLED, NULL}
@@ -62,6 +81,8 @@ void pwm3init(void){
 
 void pwm4init(void){
   pwmStart(&PWMD4, &pwm4cfg);
+  //#### these functions are use to enable the channel with certain pulse width.
+  //#### the pulse width function can be found in the official documentation in the link above.
 //  pwmEnableChannel(&PWMD4, 0, PWM_PERCENTAGE_TO_WIDTH(&PWMD4, 1000));
 //  pwmEnableChannel(&PWMD4, 1, PWM_PERCENTAGE_TO_WIDTH(&PWMD4, 1000));
 }

--- a/dev/pwm_struct.c
+++ b/dev/pwm_struct.c
@@ -1,0 +1,75 @@
+/*
+ * pwm_struct.c
+ *
+ *  Created on: 22 Dec, 2017
+ *      Author: ASUS
+ */
+
+#include "ch.h"
+#include "hal.h"
+
+//http://chibios.sourceforge.net/html/group___p_w_m.html#gaef1826611f5a65369e9e02d04e81ed61
+// This is the link to the CHIBIos Documentation on PWMD. You can find all the necessary functions
+// to command the PWM output in this webpage
+
+static PWMConfig pwm3cfg = {
+        100000,   /* 1MHz PWM clock frequency.   */
+        1000,      /* Initial PWM period 1ms.       */
+        NULL,
+        {
+                {PWM_OUTPUT_ACTIVE_HIGH, NULL},
+                {PWM_OUTPUT_ACTIVE_HIGH, NULL},
+                {PWM_OUTPUT_DISABLED, NULL},
+                {PWM_OUTPUT_DISABLED, NULL}
+        },
+        0,
+        0
+};
+
+static PWMConfig pwm4cfg = {
+        100000,   /* 1MHz PWM clock frequency.   */
+        1000,      /* Initial PWM period 1ms.       */
+        NULL,
+        {
+                {PWM_OUTPUT_ACTIVE_HIGH, NULL},
+                {PWM_OUTPUT_ACTIVE_HIGH, NULL},
+                {PWM_OUTPUT_DISABLED, NULL},
+                {PWM_OUTPUT_DISABLED, NULL}
+        },
+        0,
+        0
+};
+
+static PWMConfig pwm8cfg = {
+        100000,   /* 1MHz PWM clock frequency.   */
+        1000,      /* Initial PWM period 1ms.       */
+        NULL,
+        {
+                {PWM_OUTPUT_ACTIVE_HIGH, NULL},
+                {PWM_OUTPUT_ACTIVE_HIGH, NULL},
+                {PWM_OUTPUT_ACTIVE_HIGH, NULL},
+                {PWM_OUTPUT_ACTIVE_HIGH, NULL}
+        },
+        0,
+        0
+};
+
+void pwm3init(void){
+  // Channel 1 is for the buzzer
+  // Channel 2 is for the IMU heating element
+  pwmStart(&PWMD3, &pwm3cfg);
+}
+
+void pwm4init(void){
+  pwmStart(&PWMD4, &pwm4cfg);
+//  pwmEnableChannel(&PWMD4, 0, PWM_PERCENTAGE_TO_WIDTH(&PWMD4, 1000));
+//  pwmEnableChannel(&PWMD4, 1, PWM_PERCENTAGE_TO_WIDTH(&PWMD4, 1000));
+}
+
+void pwm8init(void){
+  pwmStart(&PWMD8, &pwm8cfg);
+//  pwmEnableChannel(&PWMD8, 0, PWM_PERCENTAGE_TO_WIDTH(&PWMD8, 9000));
+//  pwmEnableChannel(&PWMD8, 1, PWM_PERCENTAGE_TO_WIDTH(&PWMD8, 9000));
+//  pwmEnableChannel(&PWMD8, 2, PWM_PERCENTAGE_TO_WIDTH(&PWMD8, 9000));
+//  pwmEnableChannel(&PWMD8, 3, PWM_PERCENTAGE_TO_WIDTH(&PWMD8, 9000));
+}

--- a/hw/board.h
+++ b/hw/board.h
@@ -129,7 +129,7 @@
 
 #define GPIOE_PIN0                  0U
 #define GPIOE_PIN1                  1U
-#define GPIOE_PIN2                  2U
+#define GPIOE_IST8310_RST                  2U
 #define GPIOE_PIN3                  3U
 #define GPIOE_SPI4_NSS              4U
 #define GPIOE_SPI4_MISO             5U
@@ -767,7 +767,7 @@
  */
 #define VAL_GPIOE_MODER             (PIN_MODE_INPUT(GPIOE_PIN0) |           \
                                      PIN_MODE_INPUT(GPIOE_PIN1) |           \
-                                     PIN_MODE_INPUT(GPIOE_PIN2) |           \
+                                     PIN_MODE_OUTPUT(GPIOE_IST8310_RST) |           \
                                      PIN_MODE_INPUT(GPIOE_PIN3) |        \
                                      PIN_MODE_OUTPUT(GPIOE_SPI4_NSS) |           \
                                      PIN_MODE_ALTERNATE(GPIOE_SPI4_MISO) |           \
@@ -783,7 +783,7 @@
                                      PIN_MODE_INPUT(GPIOE_PIN15))
 #define VAL_GPIOE_OTYPER            (PIN_OTYPE_PUSHPULL(GPIOE_PIN0) |       \
                                      PIN_OTYPE_PUSHPULL(GPIOE_PIN1) |       \
-                                     PIN_OTYPE_PUSHPULL(GPIOE_PIN2) |       \
+                                     PIN_OTYPE_PUSHPULL(GPIOE_IST8310_RST) |       \
                                      PIN_OTYPE_PUSHPULL(GPIOE_PIN3) |     \
                                      PIN_OTYPE_PUSHPULL(GPIOE_SPI4_NSS) |       \
                                      PIN_OTYPE_PUSHPULL(GPIOE_SPI4_MISO) |       \
@@ -799,7 +799,7 @@
                                      PIN_OTYPE_PUSHPULL(GPIOE_PIN15))
 #define VAL_GPIOE_OSPEEDR           (PIN_OSPEED_HIGH(GPIOE_PIN0) |          \
                                      PIN_OSPEED_HIGH(GPIOE_PIN1) |          \
-                                     PIN_OSPEED_HIGH(GPIOE_PIN2) |          \
+                                     PIN_OSPEED_HIGH(GPIOE_IST8310_RST) |          \
                                      PIN_OSPEED_HIGH(GPIOE_PIN3) |        \
                                      PIN_OSPEED_HIGH(GPIOE_SPI4_NSS) |          \
                                      PIN_OSPEED_HIGH(GPIOE_SPI4_MISO) |          \
@@ -815,7 +815,7 @@
                                      PIN_OSPEED_HIGH(GPIOE_PIN15))
 #define VAL_GPIOE_PUPDR             (PIN_PUPDR_FLOATING(GPIOE_PIN0) |       \
                                      PIN_PUPDR_FLOATING(GPIOE_PIN1) |       \
-                                     PIN_PUPDR_FLOATING(GPIOE_PIN2) |       \
+                                     PIN_PUPDR_FLOATING(GPIOE_IST8310_RST) |       \
                                      PIN_PUPDR_FLOATING(GPIOE_PIN3) |     \
                                      PIN_PUPDR_PULLUP(GPIOE_SPI4_NSS) |       \
                                      PIN_PUPDR_PULLDOWN(GPIOE_SPI4_MISO) |       \
@@ -831,7 +831,7 @@
                                      PIN_PUPDR_FLOATING(GPIOE_PIN15))
 #define VAL_GPIOE_ODR               (PIN_ODR_HIGH(GPIOE_PIN0) |             \
                                      PIN_ODR_HIGH(GPIOE_PIN1) |             \
-                                     PIN_ODR_HIGH(GPIOE_PIN2) |             \
+                                     PIN_ODR_LOW(GPIOE_IST8310_RST) |             \
                                      PIN_ODR_HIGH(GPIOE_PIN3) |           \
                                      PIN_ODR_HIGH(GPIOE_SPI4_NSS) |             \
                                      PIN_ODR_HIGH(GPIOE_SPI4_MISO) |             \
@@ -847,7 +847,7 @@
                                      PIN_ODR_HIGH(GPIOE_PIN15))
 #define VAL_GPIOE_AFRL              (PIN_AFIO_AF(GPIOE_PIN0, 0U) |          \
                                      PIN_AFIO_AF(GPIOE_PIN1, 0U) |          \
-                                     PIN_AFIO_AF(GPIOE_PIN2, 0U) |          \
+                                     PIN_AFIO_AF(GPIOE_IST8310_RST, 0U) |          \
                                      PIN_AFIO_AF(GPIOE_PIN3, 0U) |        \
                                      PIN_AFIO_AF(GPIOE_SPI4_NSS, 5U) |          \
                                      PIN_AFIO_AF(GPIOE_SPI4_MISO, 5U) |          \

--- a/hw/board.h
+++ b/hw/board.h
@@ -55,6 +55,7 @@
  */
 #define STM32F427xx
 #define BOARD_OTG_NOVBUSSENS
+#include "stm32f4xx.h"
 
 /*
  * IO pins assignments.
@@ -124,12 +125,12 @@
 #define GPIOD_PIN11                 11U
 #define GPIOD_TIM4_CH1              12U
 #define GPIOD_TIM4_CH2              13U
-#define GPIOD_TIM4_CH3              14U
-#define GPIOD_TIM4_CH4              15U
+#define GPIOD_PNEUMATICS1            14U
+#define GPIOD_PNEUMATICS2            15U
 
 #define GPIOE_PIN0                  0U
 #define GPIOE_PIN1                  1U
-#define GPIOE_IST8310_RST                  2U
+#define GPIOE_PIN2                  2U
 #define GPIOE_PIN3                  3U
 #define GPIOE_SPI4_NSS              4U
 #define GPIOE_SPI4_MISO             5U
@@ -188,21 +189,21 @@
 #define GPIOH_PIN7                  7U
 #define GPIOH_PIN8                  8U
 #define GPIOH_PIN9                  9U
-#define GPIOH_PIN10                 10U
-#define GPIOH_PIN11                 11U
-#define GPIOH_PIN12                 12U
+#define GPIOH_PNEUMATICS3           10U
+#define GPIOH_PNEUMATICS4           11U
+#define GPIOH_PNEUMATICS5           12U
 #define GPIOH_PIN13                 13U
 #define GPIOH_PIN14                 14U
 #define GPIOH_PIN15                 15U
 
-#define GPIOI_PIN0                  0U
+#define GPIOI_PNEUMATICS6           0U
 #define GPIOI_PIN1                  1U
-#define GPIOI_PIN2                  2U
+#define GPIOI_TIM8_CH4              2U
 #define GPIOI_PIN3                  3U
 #define GPIOI_PIN4                  4U
-#define GPIOI_PIN5                  5U
-#define GPIOI_PIN6                  6U
-#define GPIOI_PIN7                  7U
+#define GPIOI_TIM8_CH1              5U
+#define GPIOI_TIM8_CH2              6U
+#define GPIOI_TIM8_CH3              7U
 #define GPIOI_PIN8                  8U
 #define GPIOI_PIN9                  9U
 #define GPIOI_PIN10                 10U
@@ -299,8 +300,8 @@
  */
 #define VAL_GPIOA_MODER             (PIN_MODE_ALTERNATE(GPIOA_TIM2_CH1) |         \
                                      PIN_MODE_ALTERNATE(GPIOA_TIM2_CH2) |           \
-                                     PIN_MODE_ALTERNATE(GPIOA_TIM2_CH3) |           \
-                                     PIN_MODE_ALTERNATE(GPIOA_TIM2_CH4) |           \
+                                     PIN_MODE_OUTPUT(GPIOA_TIM2_CH3) |           \
+                                     PIN_MODE_OUTPUT(GPIOA_TIM2_CH4) |           \
                                      PIN_MODE_INPUT(GPIOA_PIN4) |       \
                                      PIN_MODE_INPUT(GPIOA_PIN5) |        \
                                      PIN_MODE_INPUT(GPIOA_PIN6) |        \
@@ -362,8 +363,8 @@
                                      PIN_PUPDR_PULLUP(GPIOA_SWCLK) |      \
                                      PIN_PUPDR_FLOATING(GPIOA_PIN15))
 #define VAL_GPIOA_ODR               (PIN_ODR_HIGH(GPIOA_TIM2_CH1) |           \
-                                     PIN_ODR_HIGH(GPIOA_TIM2_CH2) |             \
-                                     PIN_ODR_HIGH(GPIOA_TIM2_CH3) |             \
+                                     PIN_ODR_LOW(GPIOA_TIM2_CH2) |             \
+                                     PIN_ODR_LOW(GPIOA_TIM2_CH3) |             \
                                      PIN_ODR_HIGH(GPIOA_TIM2_CH4) |             \
                                      PIN_ODR_HIGH(GPIOA_PIN4) |             \
                                      PIN_ODR_HIGH(GPIOA_PIN5) |              \
@@ -377,10 +378,10 @@
                                      PIN_ODR_HIGH(GPIOA_SWDIO) |            \
                                      PIN_ODR_HIGH(GPIOA_SWCLK) |            \
                                      PIN_ODR_HIGH(GPIOA_PIN15))
-#define VAL_GPIOA_AFRL              (PIN_AFIO_AF(GPIOA_TIM2_CH1, 1U) |        \
-                                     PIN_AFIO_AF(GPIOA_TIM2_CH2, 1U) |          \
-                                     PIN_AFIO_AF(GPIOA_TIM2_CH3, 1U) |          \
-                                     PIN_AFIO_AF(GPIOA_TIM2_CH4, 1U) |          \
+#define VAL_GPIOA_AFRL              (PIN_AFIO_AF(GPIOA_TIM2_CH1, 0U) |        \
+                                     PIN_AFIO_AF(GPIOA_TIM2_CH2, 0U) |          \
+                                     PIN_AFIO_AF(GPIOA_TIM2_CH3, 0U) |          \
+                                     PIN_AFIO_AF(GPIOA_TIM2_CH4, 0U) |          \
                                      PIN_AFIO_AF(GPIOA_PIN4, 0U) |          \
                                      PIN_AFIO_AF(GPIOA_PIN5, 0U) |           \
                                      PIN_AFIO_AF(GPIOA_PIN6, 0U) |           \
@@ -662,8 +663,8 @@
                                      PIN_MODE_INPUT(GPIOD_PIN11) |          \
                                      PIN_MODE_ALTERNATE(GPIOD_TIM4_CH1) |          \
                                      PIN_MODE_ALTERNATE(GPIOD_TIM4_CH2) |          \
-                                     PIN_MODE_ALTERNATE(GPIOD_TIM4_CH3) |          \
-                                     PIN_MODE_ALTERNATE(GPIOD_TIM4_CH4))
+                                     PIN_MODE_OUTPUT(GPIOD_PNEUMATICS1) |          \
+                                     PIN_MODE_OUTPUT(GPIOD_PNEUMATICS2))
 #define VAL_GPIOD_OTYPER            (PIN_OTYPE_PUSHPULL(GPIOD_CAN1_RX) |       \
                                      PIN_OTYPE_PUSHPULL(GPIOD_CAN1_TX) |       \
                                      PIN_OTYPE_PUSHPULL(GPIOD_PIN2) |       \
@@ -678,8 +679,8 @@
                                      PIN_OTYPE_PUSHPULL(GPIOD_PIN11) |      \
                                      PIN_OTYPE_PUSHPULL(GPIOD_TIM4_CH1) |       \
                                      PIN_OTYPE_PUSHPULL(GPIOD_TIM4_CH2) |       \
-                                     PIN_OTYPE_PUSHPULL(GPIOD_TIM4_CH3) |       \
-                                     PIN_OTYPE_PUSHPULL(GPIOD_TIM4_CH4))
+                                     PIN_OTYPE_PUSHPULL(GPIOD_PNEUMATICS1) |       \
+                                     PIN_OTYPE_PUSHPULL(GPIOD_PNEUMATICS2))
 #define VAL_GPIOD_OSPEEDR           (PIN_OSPEED_HIGH(GPIOD_CAN1_RX) |          \
                                      PIN_OSPEED_HIGH(GPIOD_CAN1_TX) |          \
                                      PIN_OSPEED_HIGH(GPIOD_PIN2) |          \
@@ -694,8 +695,8 @@
                                      PIN_OSPEED_HIGH(GPIOD_PIN11) |         \
                                      PIN_OSPEED_HIGH(GPIOD_TIM4_CH1) |          \
                                      PIN_OSPEED_HIGH(GPIOD_TIM4_CH2) |          \
-                                     PIN_OSPEED_HIGH(GPIOD_TIM4_CH3) |          \
-                                     PIN_OSPEED_HIGH(GPIOD_TIM4_CH4))
+                                     PIN_OSPEED_HIGH(GPIOD_PNEUMATICS1) |          \
+                                     PIN_OSPEED_HIGH(GPIOD_PNEUMATICS2))
 #define VAL_GPIOD_PUPDR             (PIN_PUPDR_PULLDOWN(GPIOD_CAN1_RX) |         \
                                      PIN_PUPDR_PULLDOWN(GPIOD_CAN1_TX) |         \
                                      PIN_PUPDR_FLOATING(GPIOD_PIN2) |         \
@@ -710,8 +711,8 @@
                                      PIN_PUPDR_FLOATING(GPIOD_PIN11) |        \
                                      PIN_PUPDR_PULLDOWN(GPIOD_TIM4_CH1) |       \
                                      PIN_PUPDR_PULLDOWN(GPIOD_TIM4_CH2) |       \
-                                     PIN_PUPDR_PULLDOWN(GPIOD_TIM4_CH3) |       \
-                                     PIN_PUPDR_PULLDOWN(GPIOD_TIM4_CH4))
+                                     PIN_PUPDR_PULLDOWN(GPIOD_PNEUMATICS1) |       \
+                                     PIN_PUPDR_PULLDOWN(GPIOD_PNEUMATICS2))
 #define VAL_GPIOD_ODR               (PIN_ODR_HIGH(GPIOD_CAN1_RX) |             \
                                      PIN_ODR_HIGH(GPIOD_CAN1_TX) |             \
                                      PIN_ODR_HIGH(GPIOD_PIN2) |             \
@@ -726,8 +727,8 @@
                                      PIN_ODR_HIGH(GPIOD_PIN11) |            \
                                      PIN_ODR_HIGH(GPIOD_TIM4_CH1) |              \
                                      PIN_ODR_HIGH(GPIOD_TIM4_CH2) |              \
-                                     PIN_ODR_HIGH(GPIOD_TIM4_CH3) |              \
-                                     PIN_ODR_HIGH(GPIOD_TIM4_CH4))
+                                     PIN_ODR_LOW(GPIOD_PNEUMATICS1) |              \
+                                     PIN_ODR_LOW(GPIOD_PNEUMATICS2))
 #define VAL_GPIOD_AFRL              (PIN_AFIO_AF(GPIOD_CAN1_RX, 9U) |          \
                                      PIN_AFIO_AF(GPIOD_CAN1_TX, 9U) |          \
                                      PIN_AFIO_AF(GPIOD_PIN2, 0U) |          \
@@ -742,8 +743,8 @@
                                      PIN_AFIO_AF(GPIOD_PIN11, 0U) |         \
                                      PIN_AFIO_AF(GPIOD_TIM4_CH1, 2U) |          \
                                      PIN_AFIO_AF(GPIOD_TIM4_CH2, 2U) |          \
-                                     PIN_AFIO_AF(GPIOD_TIM4_CH3, 2U) |          \
-                                     PIN_AFIO_AF(GPIOD_TIM4_CH4, 2U))
+                                     PIN_AFIO_AF(GPIOD_PNEUMATICS1, 0U) |          \
+                                     PIN_AFIO_AF(GPIOD_PNEUMATICS2, 0U))
 
 /*
  * GPIOE setup:
@@ -755,7 +756,7 @@
  * PE4  - PIN4                      (input floating).
  * PE5  - PIN5                      (input floating).
  * PE6  - PIN6                      (input floating).
- * PE7  - PIN7                      (input floating).
+ * PE7  - PIN7                      (LED TIM1-ETR).
  * PE8  - PIN8                      (input floating).
  * PE9  - PIN9                      (input floating).
  * PE10 - PIN10                     (input floating).
@@ -767,7 +768,7 @@
  */
 #define VAL_GPIOE_MODER             (PIN_MODE_INPUT(GPIOE_PIN0) |           \
                                      PIN_MODE_INPUT(GPIOE_PIN1) |           \
-                                     PIN_MODE_OUTPUT(GPIOE_IST8310_RST) |           \
+                                     PIN_MODE_INPUT(GPIOE_PIN2) |           \
                                      PIN_MODE_INPUT(GPIOE_PIN3) |        \
                                      PIN_MODE_OUTPUT(GPIOE_SPI4_NSS) |           \
                                      PIN_MODE_ALTERNATE(GPIOE_SPI4_MISO) |           \
@@ -783,7 +784,7 @@
                                      PIN_MODE_INPUT(GPIOE_PIN15))
 #define VAL_GPIOE_OTYPER            (PIN_OTYPE_PUSHPULL(GPIOE_PIN0) |       \
                                      PIN_OTYPE_PUSHPULL(GPIOE_PIN1) |       \
-                                     PIN_OTYPE_PUSHPULL(GPIOE_IST8310_RST) |       \
+                                     PIN_OTYPE_PUSHPULL(GPIOE_PIN2) |       \
                                      PIN_OTYPE_PUSHPULL(GPIOE_PIN3) |     \
                                      PIN_OTYPE_PUSHPULL(GPIOE_SPI4_NSS) |       \
                                      PIN_OTYPE_PUSHPULL(GPIOE_SPI4_MISO) |       \
@@ -799,7 +800,7 @@
                                      PIN_OTYPE_PUSHPULL(GPIOE_PIN15))
 #define VAL_GPIOE_OSPEEDR           (PIN_OSPEED_HIGH(GPIOE_PIN0) |          \
                                      PIN_OSPEED_HIGH(GPIOE_PIN1) |          \
-                                     PIN_OSPEED_HIGH(GPIOE_IST8310_RST) |          \
+                                     PIN_OSPEED_HIGH(GPIOE_PIN2) |          \
                                      PIN_OSPEED_HIGH(GPIOE_PIN3) |        \
                                      PIN_OSPEED_HIGH(GPIOE_SPI4_NSS) |          \
                                      PIN_OSPEED_HIGH(GPIOE_SPI4_MISO) |          \
@@ -815,7 +816,7 @@
                                      PIN_OSPEED_HIGH(GPIOE_PIN15))
 #define VAL_GPIOE_PUPDR             (PIN_PUPDR_FLOATING(GPIOE_PIN0) |       \
                                      PIN_PUPDR_FLOATING(GPIOE_PIN1) |       \
-                                     PIN_PUPDR_FLOATING(GPIOE_IST8310_RST) |       \
+                                     PIN_PUPDR_FLOATING(GPIOE_PIN2) |       \
                                      PIN_PUPDR_FLOATING(GPIOE_PIN3) |     \
                                      PIN_PUPDR_PULLUP(GPIOE_SPI4_NSS) |       \
                                      PIN_PUPDR_PULLDOWN(GPIOE_SPI4_MISO) |       \
@@ -831,7 +832,7 @@
                                      PIN_PUPDR_FLOATING(GPIOE_PIN15))
 #define VAL_GPIOE_ODR               (PIN_ODR_HIGH(GPIOE_PIN0) |             \
                                      PIN_ODR_HIGH(GPIOE_PIN1) |             \
-                                     PIN_ODR_LOW(GPIOE_IST8310_RST) |             \
+                                     PIN_ODR_HIGH(GPIOE_PIN2) |             \
                                      PIN_ODR_HIGH(GPIOE_PIN3) |           \
                                      PIN_ODR_HIGH(GPIOE_SPI4_NSS) |             \
                                      PIN_ODR_HIGH(GPIOE_SPI4_MISO) |             \
@@ -847,12 +848,12 @@
                                      PIN_ODR_HIGH(GPIOE_PIN15))
 #define VAL_GPIOE_AFRL              (PIN_AFIO_AF(GPIOE_PIN0, 0U) |          \
                                      PIN_AFIO_AF(GPIOE_PIN1, 0U) |          \
-                                     PIN_AFIO_AF(GPIOE_IST8310_RST, 0U) |          \
+                                     PIN_AFIO_AF(GPIOE_PIN2, 0U) |          \
                                      PIN_AFIO_AF(GPIOE_PIN3, 0U) |        \
                                      PIN_AFIO_AF(GPIOE_SPI4_NSS, 5U) |          \
                                      PIN_AFIO_AF(GPIOE_SPI4_MISO, 5U) |          \
                                      PIN_AFIO_AF(GPIOE_SPI4_MOSI, 5U) |          \
-                                     PIN_AFIO_AF(GPIOE_LED_R, 0U))
+                                     PIN_AFIO_AF(GPIOE_LED_R, 1U))
 #define VAL_GPIOE_AFRH              (PIN_AFIO_AF(GPIOE_PIN8, 0U) |          \
                                      PIN_AFIO_AF(GPIOE_PIN9, 0U) |          \
                                      PIN_AFIO_AF(GPIOE_PIN10, 0U) |         \
@@ -1126,9 +1127,9 @@
                                      PIN_MODE_INPUT(GPIOH_PIN7) |           \
                                      PIN_MODE_INPUT(GPIOH_PIN8) |           \
                                      PIN_MODE_INPUT(GPIOH_PIN9) |           \
-                                     PIN_MODE_INPUT(GPIOH_PIN10) |          \
-                                     PIN_MODE_INPUT(GPIOH_PIN11) |          \
-                                     PIN_MODE_INPUT(GPIOH_PIN12) |          \
+                                     PIN_MODE_OUTPUT(GPIOH_PNEUMATICS3) |          \
+                                     PIN_MODE_OUTPUT(GPIOH_PNEUMATICS4) |          \
+                                     PIN_MODE_OUTPUT(GPIOH_PNEUMATICS5) |          \
                                      PIN_MODE_INPUT(GPIOH_PIN13) |          \
                                      PIN_MODE_INPUT(GPIOH_PIN14) |          \
                                      PIN_MODE_INPUT(GPIOH_PIN15))
@@ -1142,9 +1143,9 @@
                                      PIN_OTYPE_PUSHPULL(GPIOH_PIN7) |       \
                                      PIN_OTYPE_PUSHPULL(GPIOH_PIN8) |       \
                                      PIN_OTYPE_PUSHPULL(GPIOH_PIN9) |       \
-                                     PIN_OTYPE_PUSHPULL(GPIOH_PIN10) |      \
-                                     PIN_OTYPE_PUSHPULL(GPIOH_PIN11) |      \
-                                     PIN_OTYPE_PUSHPULL(GPIOH_PIN12) |      \
+                                     PIN_OTYPE_PUSHPULL(GPIOH_PNEUMATICS3) |      \
+                                     PIN_OTYPE_PUSHPULL(GPIOH_PNEUMATICS4) |      \
+                                     PIN_OTYPE_PUSHPULL(GPIOH_PNEUMATICS5) |      \
                                      PIN_OTYPE_PUSHPULL(GPIOH_PIN13) |      \
                                      PIN_OTYPE_PUSHPULL(GPIOH_PIN14) |      \
                                      PIN_OTYPE_PUSHPULL(GPIOH_PIN15))
@@ -1158,9 +1159,9 @@
                                      PIN_OSPEED_HIGH(GPIOH_PIN7) |          \
                                      PIN_OSPEED_HIGH(GPIOH_PIN8) |          \
                                      PIN_OSPEED_HIGH(GPIOH_PIN9) |          \
-                                     PIN_OSPEED_HIGH(GPIOH_PIN10) |         \
-                                     PIN_OSPEED_HIGH(GPIOH_PIN11) |         \
-                                     PIN_OSPEED_HIGH(GPIOH_PIN12) |         \
+                                     PIN_OSPEED_HIGH(GPIOH_PNEUMATICS3) |         \
+                                     PIN_OSPEED_HIGH(GPIOH_PNEUMATICS4) |         \
+                                     PIN_OSPEED_HIGH(GPIOH_PNEUMATICS5) |         \
                                      PIN_OSPEED_HIGH(GPIOH_PIN13) |         \
                                      PIN_OSPEED_HIGH(GPIOH_PIN14) |         \
                                      PIN_OSPEED_HIGH(GPIOH_PIN15))
@@ -1174,9 +1175,9 @@
                                      PIN_PUPDR_FLOATING(GPIOH_PIN7) |       \
                                      PIN_PUPDR_FLOATING(GPIOH_PIN8) |       \
                                      PIN_PUPDR_FLOATING(GPIOH_PIN9) |       \
-                                     PIN_PUPDR_FLOATING(GPIOH_PIN10) |      \
-                                     PIN_PUPDR_FLOATING(GPIOH_PIN11) |      \
-                                     PIN_PUPDR_FLOATING(GPIOH_PIN12) |      \
+                                     PIN_PUPDR_PULLDOWN(GPIOH_PNEUMATICS3) |      \
+                                     PIN_PUPDR_PULLDOWN(GPIOH_PNEUMATICS4) |      \
+                                     PIN_PUPDR_PULLDOWN(GPIOH_PNEUMATICS5) |      \
                                      PIN_PUPDR_FLOATING(GPIOH_PIN13) |      \
                                      PIN_PUPDR_FLOATING(GPIOH_PIN14) |      \
                                      PIN_PUPDR_FLOATING(GPIOH_PIN15))
@@ -1190,9 +1191,9 @@
                                      PIN_ODR_HIGH(GPIOH_PIN7) |             \
                                      PIN_ODR_HIGH(GPIOH_PIN8) |             \
                                      PIN_ODR_HIGH(GPIOH_PIN9) |             \
-                                     PIN_ODR_HIGH(GPIOH_PIN10) |            \
-                                     PIN_ODR_HIGH(GPIOH_PIN11) |            \
-                                     PIN_ODR_HIGH(GPIOH_PIN12) |            \
+                                     PIN_ODR_LOW(GPIOH_PNEUMATICS3) |            \
+                                     PIN_ODR_LOW(GPIOH_PNEUMATICS4) |            \
+                                     PIN_ODR_LOW(GPIOH_PNEUMATICS5) |            \
                                      PIN_ODR_HIGH(GPIOH_PIN13) |            \
                                      PIN_ODR_HIGH(GPIOH_PIN14) |            \
                                      PIN_ODR_HIGH(GPIOH_PIN15))
@@ -1206,9 +1207,9 @@
                                      PIN_AFIO_AF(GPIOH_PIN7, 0U))
 #define VAL_GPIOH_AFRH              (PIN_AFIO_AF(GPIOH_PIN8, 0U) |          \
                                      PIN_AFIO_AF(GPIOH_PIN9, 0U) |          \
-                                     PIN_AFIO_AF(GPIOH_PIN10, 0U) |         \
-                                     PIN_AFIO_AF(GPIOH_PIN11, 0U) |         \
-                                     PIN_AFIO_AF(GPIOH_PIN12, 0U) |         \
+                                     PIN_AFIO_AF(GPIOH_PNEUMATICS3, 0U) |         \
+                                     PIN_AFIO_AF(GPIOH_PNEUMATICS4, 0U) |         \
+                                     PIN_AFIO_AF(GPIOH_PNEUMATICS5, 0U) |         \
                                      PIN_AFIO_AF(GPIOH_PIN13, 0U) |         \
                                      PIN_AFIO_AF(GPIOH_PIN14, 0U) |         \
                                      PIN_AFIO_AF(GPIOH_PIN15, 0U))
@@ -1233,14 +1234,14 @@
  * PI14 - PIN14                     (input floating).
  * PI15 - PIN15                     (input floating).
  */
-#define VAL_GPIOI_MODER             (PIN_MODE_INPUT(GPIOI_PIN0) |           \
+#define VAL_GPIOI_MODER             (PIN_MODE_OUTPUT(GPIOI_PNEUMATICS6) |           \
                                      PIN_MODE_INPUT(GPIOI_PIN1) |           \
-                                     PIN_MODE_INPUT(GPIOI_PIN2) |           \
+                                     PIN_MODE_ALTERNATE(GPIOI_TIM8_CH4) |           \
                                      PIN_MODE_INPUT(GPIOI_PIN3) |           \
                                      PIN_MODE_INPUT(GPIOI_PIN4) |           \
-                                     PIN_MODE_INPUT(GPIOI_PIN5) |           \
-                                     PIN_MODE_INPUT(GPIOI_PIN6) |           \
-                                     PIN_MODE_INPUT(GPIOI_PIN7) |           \
+                                     PIN_MODE_ALTERNATE(GPIOI_TIM8_CH1) |           \
+                                     PIN_MODE_ALTERNATE(GPIOI_TIM8_CH2) |           \
+                                     PIN_MODE_ALTERNATE(GPIOI_TIM8_CH3) |           \
                                      PIN_MODE_INPUT(GPIOI_PIN8) |           \
                                      PIN_MODE_INPUT(GPIOI_PIN9) |           \
                                      PIN_MODE_INPUT(GPIOI_PIN10) |          \
@@ -1249,14 +1250,14 @@
                                      PIN_MODE_INPUT(GPIOI_PIN13) |          \
                                      PIN_MODE_INPUT(GPIOI_PIN14) |          \
                                      PIN_MODE_INPUT(GPIOI_PIN15))
-#define VAL_GPIOI_OTYPER            (PIN_OTYPE_PUSHPULL(GPIOI_PIN0) |       \
+#define VAL_GPIOI_OTYPER            (PIN_OTYPE_PUSHPULL(GPIOI_PNEUMATICS6) |       \
                                      PIN_OTYPE_PUSHPULL(GPIOI_PIN1) |       \
-                                     PIN_OTYPE_PUSHPULL(GPIOI_PIN2) |       \
+                                     PIN_OTYPE_PUSHPULL(GPIOI_TIM8_CH4) |       \
                                      PIN_OTYPE_PUSHPULL(GPIOI_PIN3) |       \
                                      PIN_OTYPE_PUSHPULL(GPIOI_PIN4) |       \
-                                     PIN_OTYPE_PUSHPULL(GPIOI_PIN5) |       \
-                                     PIN_OTYPE_PUSHPULL(GPIOI_PIN6) |       \
-                                     PIN_OTYPE_PUSHPULL(GPIOI_PIN7) |       \
+                                     PIN_OTYPE_PUSHPULL(GPIOI_TIM8_CH1) |       \
+                                     PIN_OTYPE_PUSHPULL(GPIOI_TIM8_CH2) |       \
+                                     PIN_OTYPE_PUSHPULL(GPIOI_TIM8_CH3) |       \
                                      PIN_OTYPE_PUSHPULL(GPIOI_PIN8) |       \
                                      PIN_OTYPE_PUSHPULL(GPIOI_PIN9) |       \
                                      PIN_OTYPE_PUSHPULL(GPIOI_PIN10) |      \
@@ -1265,14 +1266,14 @@
                                      PIN_OTYPE_PUSHPULL(GPIOI_PIN13) |      \
                                      PIN_OTYPE_PUSHPULL(GPIOI_PIN14) |      \
                                      PIN_OTYPE_PUSHPULL(GPIOI_PIN15))
-#define VAL_GPIOI_OSPEEDR           (PIN_OSPEED_HIGH(GPIOI_PIN0) |          \
+#define VAL_GPIOI_OSPEEDR           (PIN_OSPEED_HIGH(GPIOI_PNEUMATICS6) |          \
                                      PIN_OSPEED_HIGH(GPIOI_PIN1) |          \
-                                     PIN_OSPEED_HIGH(GPIOI_PIN2) |          \
+                                     PIN_OSPEED_HIGH(GPIOI_TIM8_CH4) |          \
                                      PIN_OSPEED_HIGH(GPIOI_PIN3) |          \
                                      PIN_OSPEED_HIGH(GPIOI_PIN4) |          \
-                                     PIN_OSPEED_HIGH(GPIOI_PIN5) |          \
-                                     PIN_OSPEED_HIGH(GPIOI_PIN6) |          \
-                                     PIN_OSPEED_HIGH(GPIOI_PIN7) |          \
+                                     PIN_OSPEED_HIGH(GPIOI_TIM8_CH1) |          \
+                                     PIN_OSPEED_HIGH(GPIOI_TIM8_CH2) |          \
+                                     PIN_OSPEED_HIGH(GPIOI_TIM8_CH3) |          \
                                      PIN_OSPEED_HIGH(GPIOI_PIN8) |          \
                                      PIN_OSPEED_HIGH(GPIOI_PIN9) |          \
                                      PIN_OSPEED_HIGH(GPIOI_PIN10) |         \
@@ -1281,14 +1282,14 @@
                                      PIN_OSPEED_HIGH(GPIOI_PIN13) |         \
                                      PIN_OSPEED_HIGH(GPIOI_PIN14) |         \
                                      PIN_OSPEED_HIGH(GPIOI_PIN15))
-#define VAL_GPIOI_PUPDR             (PIN_PUPDR_FLOATING(GPIOI_PIN0) |       \
+#define VAL_GPIOI_PUPDR             (PIN_PUPDR_PULLDOWN(GPIOI_PNEUMATICS6) |       \
                                      PIN_PUPDR_FLOATING(GPIOI_PIN1) |       \
-                                     PIN_PUPDR_FLOATING(GPIOI_PIN2) |       \
+                                     PIN_PUPDR_PULLDOWN(GPIOI_TIM8_CH4) |       \
                                      PIN_PUPDR_FLOATING(GPIOI_PIN3) |       \
                                      PIN_PUPDR_FLOATING(GPIOI_PIN4) |       \
-                                     PIN_PUPDR_FLOATING(GPIOI_PIN5) |       \
-                                     PIN_PUPDR_FLOATING(GPIOI_PIN6) |       \
-                                     PIN_PUPDR_FLOATING(GPIOI_PIN7) |       \
+                                     PIN_PUPDR_PULLDOWN(GPIOI_TIM8_CH1) |       \
+                                     PIN_PUPDR_PULLDOWN(GPIOI_TIM8_CH2) |       \
+                                     PIN_PUPDR_PULLDOWN(GPIOI_TIM8_CH3) |       \
                                      PIN_PUPDR_FLOATING(GPIOI_PIN8) |       \
                                      PIN_PUPDR_FLOATING(GPIOI_PIN9) |       \
                                      PIN_PUPDR_FLOATING(GPIOI_PIN10) |      \
@@ -1297,14 +1298,14 @@
                                      PIN_PUPDR_FLOATING(GPIOI_PIN13) |      \
                                      PIN_PUPDR_FLOATING(GPIOI_PIN14) |      \
                                      PIN_PUPDR_FLOATING(GPIOI_PIN15))
-#define VAL_GPIOI_ODR               (PIN_ODR_HIGH(GPIOI_PIN0) |             \
+#define VAL_GPIOI_ODR               (PIN_ODR_HIGH(GPIOI_PNEUMATICS6) |             \
                                      PIN_ODR_HIGH(GPIOI_PIN1) |             \
-                                     PIN_ODR_HIGH(GPIOI_PIN2) |             \
+                                     PIN_ODR_HIGH(GPIOI_TIM8_CH4) |             \
                                      PIN_ODR_HIGH(GPIOI_PIN3) |             \
                                      PIN_ODR_HIGH(GPIOI_PIN4) |             \
-                                     PIN_ODR_HIGH(GPIOI_PIN5) |             \
-                                     PIN_ODR_HIGH(GPIOI_PIN6) |             \
-                                     PIN_ODR_HIGH(GPIOI_PIN7) |             \
+                                     PIN_ODR_HIGH(GPIOI_TIM8_CH1) |             \
+                                     PIN_ODR_HIGH(GPIOI_TIM8_CH2) |             \
+                                     PIN_ODR_HIGH(GPIOI_TIM8_CH3) |             \
                                      PIN_ODR_HIGH(GPIOI_PIN8) |             \
                                      PIN_ODR_HIGH(GPIOI_PIN9) |             \
                                      PIN_ODR_HIGH(GPIOI_PIN10) |            \
@@ -1313,14 +1314,14 @@
                                      PIN_ODR_HIGH(GPIOI_PIN13) |            \
                                      PIN_ODR_HIGH(GPIOI_PIN14) |            \
                                      PIN_ODR_HIGH(GPIOI_PIN15))
-#define VAL_GPIOI_AFRL              (PIN_AFIO_AF(GPIOI_PIN0, 0U) |          \
+#define VAL_GPIOI_AFRL              (PIN_AFIO_AF(GPIOI_PNEUMATICS6, 0U) |          \
                                      PIN_AFIO_AF(GPIOI_PIN1, 0U) |          \
-                                     PIN_AFIO_AF(GPIOI_PIN2, 0U) |          \
+                                     PIN_AFIO_AF(GPIOI_TIM8_CH4, 3U) |          \
                                      PIN_AFIO_AF(GPIOI_PIN3, 0U) |          \
                                      PIN_AFIO_AF(GPIOI_PIN4, 0U) |          \
-                                     PIN_AFIO_AF(GPIOI_PIN5, 0U) |          \
-                                     PIN_AFIO_AF(GPIOI_PIN6, 0U) |          \
-                                     PIN_AFIO_AF(GPIOI_PIN7, 0U))
+                                     PIN_AFIO_AF(GPIOI_TIM8_CH1, 3U) |          \
+                                     PIN_AFIO_AF(GPIOI_TIM8_CH2, 3U) |          \
+                                     PIN_AFIO_AF(GPIOI_TIM8_CH3, 3U))
 #define VAL_GPIOI_AFRH              (PIN_AFIO_AF(GPIOI_PIN8, 0U) |          \
                                      PIN_AFIO_AF(GPIOI_PIN9, 0U) |          \
                                      PIN_AFIO_AF(GPIOI_PIN10, 0U) |         \


### PR DESCRIPTION
**UPDATE DETAILS**

"pwm_struct.c" has been added as a template on how to define the pwm configuration structure.

1.**TIM 3:**
Channel 1: Buzzer output
Channel 2: IMU heating element output

2.**TIM 4:**
Channel 1: PWM output
Channel 2: PWM output
<Channel 3 and Channel 4 are used as Pneumatics Outputs . They are I/O ports, not PWM ports>

3.**TIM 8:**
Channel 1: PWM output
Channel 2: PWM output
Channel 3: PWM output
Channel 4: PWM output

In "halconf.h" additional Macro Functions have been defined.
Example:
#define PN1_ON()        (palSetPad(GPIOD, GPIOD_PNEUMATICS1))
#define PN1_OFF()       (palClearPad(GPIOD, GPIOD_PNEUMATICS1))
#define PN1_TOGGLE()    (palTogglePad(GPIOD, GPIOD_PNEUMATICS1))

The syntax of the macro function:
#define PNx_ON()        (palTogglePad(GPIOD, GPIOD_PNEUMATICS1))
    x : is replaced with the numbering of the pneumatic ports.

**ADDITIONAL INFORMATION:**
http://chibios.sourceforge.net/html/group___p_w_m.html#gaef1826611f5a65369e9e02d04e81ed61
This is the link to the CHIBIos Documentation on PWMD. You can find all the necessary functions
to command the PWM output in this webpage

TIM 2 can only be used as GPIO as the TIMER has been used by the RTOS system.